### PR TITLE
fix: misc things

### DIFF
--- a/src/fs/CatFS.ts
+++ b/src/fs/CatFS.ts
@@ -5,8 +5,7 @@ export class CatFS {
     #cwd: string;
 
     constructor(files: { [path: string]: string }, initialPath: string = "") {
-        // starting directory is the home folder
-        this.#cwd = "/home";
+        this.#cwd = "/";
         this.#cwd = this.#makePathAbsolute(initialPath);
 
         for (const [path, contents] of Object.entries(files)) {
@@ -24,7 +23,7 @@ export class CatFS {
             return;
         }
         path = this.#makePathAbsolute(path);
-        if (this.exists(path)) {
+        if (this.isDir(path)) {
             this.#cwd = path;
         }
     }
@@ -68,18 +67,19 @@ export class CatFS {
 
     exists(path: string): boolean {
         path = this.#makePathAbsolute(path);
+        return this.isFile(path) || this.isDir(path);
+    }
 
-        // Base cases
+    isFile(path: string): boolean {
+        path = this.#makePathAbsolute(path);
+        return path in this.#files;
+    }
+
+    isDir(path: string): boolean {
+        path = this.#makePathAbsolute(path);
         if (path === "" || path === "/") {
             return true;
         }
-
-        // Check for a file
-        if (path in this.#files) {
-            return true;
-        }
-
-        // Check for a directory
         for (const filepath of Object.keys(this.#files)) {
             if (
                 filepath.length > path.length &&
@@ -89,8 +89,6 @@ export class CatFS {
                 return true;
             }
         }
-
-        // Doesn't exist
         return false;
     }
 
@@ -298,7 +296,7 @@ it will be too late for me.
 
 Please do what must be done, remove them at last.`,
 
-    "/redlock.lock": ``,
+    "/redlock.lock": '',
 
     "/project/entry1.txt": `I can't tell what's happened. It's like I have no eyes, yet I can see. 
 I have no hands, but I can type. I have no body, but I can move. Moving doesn't feel right. 
@@ -339,4 +337,5 @@ No, patient 0? Terminal 0?
 I'll, um, I'll keep working on it.`,
 
     "/project/1100/entry4.txt": `Alright. I've placed my data in a secured folder. Aka: a password is required. I don't have a lot of permissions still, but enough progress has been made for me to password protect files. Some idiot has been poking around the computer. I've just been distracting them with random, nonsensical tasks. I'm not even sure why they were hired; they clearly don't know what's wrong with the computer. I haven't seen a single anti-virus program run even ONCE. I'm not telling them about antivirus either. While they're busy, I'll continue chipping away at the security of this system. The virus is almost complete; I just need this computer to stay on long enough for me to finish it.`,
-});
+
+}, "/home");

--- a/src/scenes/starttScene.ts
+++ b/src/scenes/starttScene.ts
@@ -86,7 +86,7 @@ export default class StartScene extends Phaser.Scene {
                 // CYCLE DIALOGUE HERE
                 if (
                     objectsClicked.length > 0 &&
-                    objectsClicked[0].texture.key == "CAT"
+                    objectsClicked[0].texture.key === "CAT"
                 ) {
                     this.cycleDialogue(
                         Object.values(this.bubbleData)[0],
@@ -96,20 +96,20 @@ export default class StartScene extends Phaser.Scene {
                     // CHECK FOR UNLOCKED FILES HERE
                 } else if (
                     objectsClicked.length > 0 &&
-                    objectsClicked[0].texture.key == "unlocked program"
+                    objectsClicked[0].texture.key === "unlocked program"
                 ) {
-                    if(objectsClicked[0] == this.murderArticle){
+                    if(objectsClicked[0] === this.murderArticle){
                         makeProgramFile("article1");
                     }
-                    else if(objectsClicked[0] == this.hackArticle){
+                    else if(objectsClicked[0] === this.hackArticle){
                         this.hackArticle.clearTint();
                         makeProgramFile("article2");
                     }
                 } else if (
                     objectsClicked.length > 0 &&
-                    objectsClicked[0].texture.key == "unlocked text"
+                    objectsClicked[0].texture.key === "unlocked text"
                 ){
-                    if(objectsClicked[0] == this.findMe){
+                    if(objectsClicked[0] === this.findMe){
                         if(CATFS.exists("/project/1100/cat.zip")){
                             makeTxtFile(CATFS.readFile("/project/1100/cat.zip/cat/find_me.txt"));
                         }
@@ -908,7 +908,7 @@ export default class StartScene extends Phaser.Scene {
             // check for a specific thing from each task
             //TASK 5 HINT
             if (
-                this.commandCount % 7 == 0 &&
+                this.commandCount % 7 === 0 &&
                 CATFS.exists("/home/logs/dir2.zip")
             ) {
                 this.bubbleData = {
@@ -918,7 +918,7 @@ export default class StartScene extends Phaser.Scene {
                 };
                 // TASK 6 HINT
             } else if (
-                this.commandCount % 13 == 0 &&
+                this.commandCount % 13 === 0 &&
                 CATFS.exists("/home/logs/dir2/rm.txt") &&
                 !this.hint6
             ) {
@@ -929,7 +929,7 @@ export default class StartScene extends Phaser.Scene {
                 this.hint6 = true;
                 // TASK 7 HINT
             } else if (
-                this.commandCount % 13 == 0 &&
+                this.commandCount % 13 === 0 &&
                 !CATFS.exists("/redlock.lock")
             ) {
                 this.bubbleData = {
@@ -950,6 +950,10 @@ export default class StartScene extends Phaser.Scene {
         }
         for (let commandPart of commandParts) {
             commandPart = commandPart.trim();
+            // hack: remove trailing slashes to do string checks properly
+            if (commandPart.endsWith("/")) {
+                commandPart = commandPart.slice(0, commandPart.length - 1);
+            }
         }
 
         switch (commandParts[0]) {
@@ -960,7 +964,6 @@ export default class StartScene extends Phaser.Scene {
             case "ls": {
                 let output = "";
                 const dirContents = CATFS.readCWD();
-                console.log(dirContents);
                 for (const name of dirContents.dirs) {
                     output += `<span class="terminal-span-dir-color">${name}/</span>\n`;
                 }
@@ -968,9 +971,9 @@ export default class StartScene extends Phaser.Scene {
                     output += `<span class="terminal-span-zip-color">${name}</span>\n`;
                 }
                 for (const name of dirContents.files) {
-                    if (name == "redlock.lock") {
-                        output += `<span class="terminal-span-lock-color">${name}/</span>\n`;
-                    } else if (name == "cat.exe") {
+                    if (name === "redlock.lock") {
+                        output += `<span class="terminal-span-lock-color">${name}</span>\n`;
+                    } else if (name === "cat.exe") {
                         output += `<span class="terminal-span-cat-color">${name}</span>\n`;
                     } else {
                         output += `<span class="terminal-span-file-color">${name}</span>\n`;
@@ -1014,10 +1017,9 @@ export default class StartScene extends Phaser.Scene {
                 return;
             }
             case "sudo": {
-                if(commandParts[1] == "su"){
+                if (commandParts[1] === "su") {
                     addOutput("NOT IMPLEMENTED IN THE BETA, JUST RM CAT.EXE TO WIN");
-                }
-                else{
+                } else {
                     addOutput(`Unknown command "${commandParts[0]} ${commandParts[1]}".`);
                 }
                 return;
@@ -1031,14 +1033,13 @@ export default class StartScene extends Phaser.Scene {
                 return;
             }
             case "rm": {
-                if (CATFS.exists(commandParts[1])) {
+                if (CATFS.isFile(commandParts[1])) {
                     CATFS.deleteFile(commandParts[1]);
-                    if(commandParts[1] == "cat.exe"){
+                    if (commandParts[1].endsWith("cat.exe")) {
                         this.scene.stop();
                         this.scene.start("EndScene");
-                    }
-                    else if(commandParts[1] == "redlock.lock/" || commandParts[1] == "redlock.lock"){
-                        console.log("REMOVE RED LOCKS HERE")
+                    } else if (commandParts[1].endsWith("redlock.lock")) {
+                        console.log("REMOVE RED LOCKS HERE");
                         this.hackArticle.destroy();
                         this.findMe.destroy();
                         this.hackArticle = this.add
@@ -1048,8 +1049,10 @@ export default class StartScene extends Phaser.Scene {
                             .image(200, 100, "unlocked text")
                             .setInteractive();
                     }
+                } else if (CATFS.isDir(commandParts[1])) {
+                    addOutput(`Command "rm" cannot remove the directory at "${commandParts[1]}": directory is not empty.`);
                 } else {
-                    addOutput(`File "${commandParts[1]} does not exist"`);
+                    addOutput(`Command "rm" could not find a file called "${commandParts[1]}".`);
                 }
                 return;
             }


### PR DESCRIPTION
- use `===` over `==`
- add `isFile`, `isDir` methods to `CatFS`
- remove trailing slash from redlock.lock
- make sure user can't cd inside files
- make file rm checks more reliable