### PR TITLE
fix: minor terminal improvements

### DIFF
--- a/src/scenes/starttScene.ts
+++ b/src/scenes/starttScene.ts
@@ -199,7 +199,7 @@ export default class StartScene extends Phaser.Scene {
             if (event.code === "Enter") {
                 blip.play();
 
-                const text = escapeHTML(terminalInput.value.trim());
+                const text = escapeHTML(terminalInput.value.trim()).replaceAll('"', "");
                 if (
                     this.terminalHistory.length === 0 ||
                     (this.terminalHistory.length > 0 &&

--- a/src/scenes/starttScene.ts
+++ b/src/scenes/starttScene.ts
@@ -252,6 +252,9 @@ export default class StartScene extends Phaser.Scene {
         terminalHistoryParent.className = "jetbrains-mono-normal";
         terminalHistoryParent.style.width = `${terminalWidth - 8}px`;
         terminalHistoryParent.style.height = `${terminalHeight - terminalInputHeight / 2 - 16}px`;
+        terminalHistoryParent.addEventListener("mouseenter", () => {
+            terminalInput.focus();
+        });
         // -- Current Directory
         const terminalCurrentDirectory = document.createElement("p");
         terminalCurrentDirectory.id = "terminal-current-directory";


### PR DESCRIPTION
Improvements taken from the beta feedback

- Text input is automatically focused when the mouse enters the terminal zone (easy way to focus it and also be able to select text to copy-paste from the history without interference)
- Quotes are automatically stripped from command input so `echo "cat"` becomes the same as `echo cat` - dumb fix but I don't want to write a whole command parser when quotes aren't necessary anywhere